### PR TITLE
Change meter identifer for disk usage to be backward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,26 @@ None
 ### Plugin Configuration Fields
 
 |Field Name|Description                                       
-|:----------|:------------------------------------------------|
-| Mount Point | The mounted point (on Linux) to check for free space. (either this or the Mounted device need to be set for the plugin to function properly). Leave it empty on Windows. |
+|:--------------|:------------------------------------------------|
+| Mount Point   | The mounted point (on Linux) to check for free space. (either this or the Mounted device need to be set for the plugin to function properly). Leave it empty on Windows. |
 | Device/Drive  |The mounted device (on Linux) or drive (on Windows) to check for free space. (either this or the Mount Point directory need to be set for the plugin to function properly)|
 | Poll Interval | How often to poll for metrics |
-| Source  | Some alias to be appended to the hostname to display in the legend for the data.|
+| Source        | Some alias to be appended to the hostname to display in the legend for the data.|
 
 ### Metrics Collected
 
-|Metric Name            |Description               |
-|:----------------------|:-------------------------|
-|Disk Use Percentage  |The percentage of disk used for the given mounted disk|
-|Total Disk Reads|The total number of disk reads at the moment|
-|Total Disk Read Bytes|The total number of bytes read from disks at the moment|
-|Total Disk Writes|The total number of disk writes at the moment|
-|Total Disk Write Bytes|The total number of bytes written to disks at the moment|
-|Disk Reads|The number of reads from the disk at the moment|
-|Disk Read Bytes|The number of bytes read from the disk at the moment|
-|Disk Writes|The number of writes to the disk at the moment|
-|Disk Write Bytes|The number of bytes written to the disk at the moment|
-|Disk IOs|The number of IO per second to the disk at the moment|
+|Metric Name            |Description                                             |
+|:----------------------|:-------------------------------------------------------|
+|Disk Use Percentage    |The percentage of disk used for the given mounted disk  |
+|Total Disk Reads       |The total number of disk reads at the moment            |
+|Total Disk Read Bytes  |The total number of bytes read from disks at the moment |
+|Total Disk Writes      |The total number of disk writes at the moment           |
+|Total Disk Write Bytes |The total number of bytes written to disks at the moment|
+|Disk Reads             |The number of reads from the disk at the moment         |
+|Disk Read Bytes        |The number of bytes read from the disk at the moment    |
+|Disk Writes            |The number of writes to the disk at the moment          |
+|Disk Write Bytes       |The number of bytes written to the disk at the moment   |
+|Disk IOs               |The number of IO per second to the disk at the moment   |
 
 ### Dashboards
 

--- a/init.lua
+++ b/init.lua
@@ -32,8 +32,8 @@ local metric_mapping = {
   ['system.disk.write_bytes.total'] = 'DISK_WRITE_BYTES_TOTAL',
   ['system.disk.write_bytes'] = 'DISK_WRITE_BYTES',
   ['system.disk.ios'] = 'DISK_IOS',
-  ['system.fs.use_percent'] = 'DISK_USE_PERCENT',
-  ['system.fs.use_percent.total'] = 'DISK_USE_PERCENT'
+  ['system.fs.use_percent'] = 'DISKUSE_SUMMARY',
+  ['system.fs.use_percent.total'] = 'DISKUSE_SUMMARY'
 }
 
 local ds = MeterDataSource:new()

--- a/metrics.json
+++ b/metrics.json
@@ -80,7 +80,7 @@
     "isDisabled": 0,
     "defaultAggregate": "avg"
   },
-  "DISK_USE_PERCENT": {
+  "DISKUSE_SUMMARY": {
     "defaultAggregate": "MAX",
     "defaultResolutionMS": 1000,
     "description": "For the configured disks, reports the highest used disk percent capacity",

--- a/plugin.json
+++ b/plugin.json
@@ -21,12 +21,12 @@
     "DISK_READ_BYTES",
     "DISK_WRITE_BYTES",
     "DISK_IOS",
-    "DISK_USE_PERCENT"
+    "DISKUSE_SUMMARY"
   ],
   "dashboards" : [ 
     {
       "name" : "Disk Summary",
-      "layout" : "d-w=3&d-h=2&d-pad=5&d-bg=none&d-g-DISK_USE_PERCENT=0-0-1-1&d-g-DISK_READS=1-0-1-1-t&d-g-DISK_WRITES=1-0-1-1-b&d-g-DISK_READ_BYTES=2-0-1-1-t&d-g-DISK_WRITE_BYTES=2-0-1-1-b&d-g-DISK_READS_TOTAL=2-1-1-1-t&d-g-DISK_WRITES_TOTAL=2-1-1-1-b&d-g-DISK_READ_BYTES_TOTAL=0-1-2-1-t&d-g-DISK_WRITE_BYTES_TOTAL=0-1-2-1-b"
+      "layout" : "d-w=3&d-h=2&d-pad=5&d-bg=none&d-g-DISKUSE_SUMMARY=0-0-1-1&d-g-DISK_READS=1-0-1-1-t&d-g-DISK_WRITES=1-0-1-1-b&d-g-DISK_READ_BYTES=2-0-1-1-t&d-g-DISK_WRITE_BYTES=2-0-1-1-b&d-g-DISK_READS_TOTAL=2-1-1-1-t&d-g-DISK_WRITES_TOTAL=2-1-1-1-b&d-g-DISK_READ_BYTES_TOTAL=0-1-2-1-t&d-g-DISK_WRITE_BYTES_TOTAL=0-1-2-1-b"
     }
   ],
   "paramArray" : { "itemTitle" : ["diskname", "dir", "device"], "schemaTitle" : "Endpoint"},


### PR DESCRIPTION
Changes to support same metric identifier in the original NodeJS disk summary usage.
